### PR TITLE
macOS: Porting and Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,17 @@ jobs:
         shell: bash
         run: |
           test/run.sh all
+
+  test-macos:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install GNU Tools, fd and ksh
+        run: brew install bash gnu-getopt coreutils findutils grep gnu-sed fd ksh93
+
+      - name: Run Tests
+        run: make test
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ It creates a index file with all directories from a directory tree and
 then searches this index to find the directory to change to. The creation of the
 index is configurable and multiple indexes can be created.
 
-
 ## Searching and changing directories
 
 Prerequisite for searching for directories is that an index is created. The
@@ -450,6 +449,21 @@ The following files are distributed:
 | `qc-index.cfg`              | Defines indexes to create.                       | `~/.qc/qc-index.cfg`   |
 | `qc_mini`                   | Minimal version of qc. See [QC Mini](#qc-mini).  | Not installed          |
 
+### Preparation for macOS
+
+On macOS additional GNU tools have to be installed, as the available BSD tools
+are missing some features, that Quick Change Directory needs.
+
+    brew install bash gnu-getopt coreutils findutils grep gnu-sed fd
+
+The qc-related scripts detect macOS and then use the GNU tools installed via
+Homebrew. E.g. they use `ggrep` instead of `grep`.
+
+The performance should be better when the environment variable `HOMEBREW_PREFIX`
+is set. See the man page of brew and search for "shellenv" or add the following
+to you profile (`~/.zprofile` or `~/.bash_profile`):
+
+    export HOMEBREW_PREFIX="$(brew --prefix)"
 
 ### I don't want to install -- just test it
 
@@ -566,6 +580,7 @@ Differences:
 * Limited expressions (`**` not supported).
 * Search is always case-sensitive (even labels).
 * Command line completion had little testing.
+* Not ported to macOS.
 * Help for `qc` and `dstore` can be displayed with `-h`.
 
 ----

--- a/dstore
+++ b/dstore
@@ -23,6 +23,23 @@ QC_DIR_INDEX="$QC_DIR/index"
 # file is managed using the command 'dstore'.
 QC_DSTORE_INDEX=$QC_DIR_DATA/index.dstore
 
+if [ "$(uname)" = "Darwin" ]; then
+    if [ -z "${HOMEBREW_PREFIX:-}" ]; then
+        HOMEBREW_PREFIX="$(dirname "$(dirname "$(command -v brew)")")"
+        if [ ! -d "$HOMEBREW_PREFIX/Cellar" ]; then
+            # Ok, call brew as last resort (slow)
+            HOMEBREW_PREFIX="$(brew --prefix)"
+        fi
+    fi
+    PATH="$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$PATH"
+    export PATH
+
+    shopt -s expand_aliases
+
+    alias grep=ggrep
+    alias sed=gsed
+fi
+
 show_help()
 {
     echo "Manually manage content of $QC_DSTORE_INDEX for usage with 'qc'."
@@ -239,7 +256,7 @@ done
 if cmp -s "$QC_DSTORE_INDEX.org" "$QC_DSTORE_INDEX"; then
     echo "No change"
 else
-    diff -N "$QC_DSTORE_INDEX.org" "$QC_DSTORE_INDEX" | grep -a -- "^[<>]" | sed "s/^</Removed:/;s/^>/Added:  /"
+    diff -N "$QC_DSTORE_INDEX.org" "$QC_DSTORE_INDEX" | sed "s/^</Removed:/;s/^>/Added:  /"
 fi
 
 rm "$QC_DSTORE_INDEX.org"

--- a/qc-backend
+++ b/qc-backend
@@ -18,6 +18,26 @@ QC_DIR_INDEX="$QC_DIR/index"
 
 CFG_FILE="$QC_DIR_CFG/qc-index.cfg"
 
+if [ "$(uname)" = "Darwin" ]; then
+    if [ -z "${HOMEBREW_PREFIX:-}" ]; then
+        HOMEBREW_PREFIX="$(dirname "$(dirname "$(command -v brew)")")"
+        if [ ! -d "$HOMEBREW_PREFIX/Cellar" ]; then
+            # Ok, call brew as last resort (slow)
+            HOMEBREW_PREFIX="$(brew --prefix)"
+        fi
+    fi
+    PATH="$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$PATH"
+    export PATH
+
+    shopt -s expand_aliases
+
+    alias grep=ggrep
+    alias sed=gsed
+    alias stat=gstat
+    alias readlink=greadlink
+    alias wc=gwc
+fi
+
 # Manual index file storing directory names and bookmarked directories. This
 # file is managed using the command 'dstore'.
 QC_DSTORE_INDEX=$QC_DIR_DATA/index.dstore

--- a/qc-build-index
+++ b/qc-build-index
@@ -38,6 +38,26 @@ CFG_FILE="$QC_DIR_CFG/qc-index.cfg"
 
 typeset -a TMP_FILES=()
 
+if [ "$(uname)" = "Darwin" ]; then
+    if [ -z "${HOMEBREW_PREFIX:-}" ]; then
+        HOMEBREW_PREFIX="$(dirname "$(dirname "$(command -v brew)")")"
+        if [ ! -d "$HOMEBREW_PREFIX/Cellar" ]; then
+            # Ok, call brew as last resort (slow)
+            HOMEBREW_PREFIX="$(brew --prefix)"
+        fi
+    fi
+    PATH="$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$PATH"
+    export PATH
+
+    shopt -s expand_aliases
+
+    alias grep=ggrep
+    alias sed=gsed
+    alias find=gfind
+    alias readlink=greadlink
+    alias wc=gwc
+fi
+
 # Detect the fd executable name. On Debian/Ubuntu the executable is named
 # 'fdfind' to prevent a name clash with another tool (package fdclone).
 FD_CMD="$(command -v fdfind)"

--- a/test/defines.shinc
+++ b/test/defines.shinc
@@ -12,6 +12,19 @@ export __QC_TEST__=true
 
 set -u
 
+if [ "$(uname)" = "Darwin" ]; then
+    if [ -n "${BASH_VERSION:-}" ]; then
+        # shellcheck disable=SC3044 # only executed in bash
+        shopt -s expand_aliases
+    fi
+
+    alias grep=ggrep
+    alias sed=gsed
+    alias find=gfind
+    alias readlink=greadlink
+    alias wc=gwc
+fi
+
 if [ -z "${script_dir:-}" ]; then
     echo ""
     echo "ERROR: required variable \$script_dir\" is not set"
@@ -144,6 +157,10 @@ trap "onExit" EXIT
 TEST_DIRECTORY="/tmp/qc-testDirectory"
 [ -d "$TEST_DIRECTORY" ] && rm -rf "$TEST_DIRECTORY"
 mkdir -p "$TEST_DIRECTORY"
+
+# On macOS this directory might be mapped to another location
+TEST_DIRECTORY="$(readlink -e "$TEST_DIRECTORY")"
+
 mkdir -p "$TEST_DIRECTORY/.qc"
 export QC_DIR="$TEST_DIRECTORY"/.qc
 export QC_DIR_INDEX="$QC_DIR/index"

--- a/test/shtest-index-qc.sh
+++ b/test/shtest-index-qc.sh
@@ -14,6 +14,7 @@ script_dir="$(cd "$(dirname "$0")" && pwd)" || exit 1
 set -u
 
 if [ -n "${BASH_VERSION:-}" ]; then
+    # shellcheck disable=SC3044 # only executed in bash
     shopt -s expand_aliases
 fi
 

--- a/test/shtest-qc-mini.sh
+++ b/test/shtest-qc-mini.sh
@@ -42,6 +42,11 @@ g2re()
 
 startTest "qc_mini"
 
+if [ "$(uname)" = "Darwin" ]; then
+    echo "qc_mini not compatible with MacOS/Darwin"
+    skipTest
+fi
+
 if [ -z "${TEST_SHELL:-}" ]; then
     if [ -n "${BASH_VERSION:-}" ]; then
         TEST_SHELL="bash"


### PR DESCRIPTION
Following GNU tools are needed from Homebrew:
 - bash
 - gnu-getopt
 - coreutils
 - findutils
 - grep
 - gnu-sed
 - fd

Tested in GitHub Workflows, but not on a real machine.

Will only get merged after some macOS user confirmed that it works.